### PR TITLE
Add support for big terminal entries

### DIFF
--- a/Edit scripts/ExportLargeFile.pas
+++ b/Edit scripts/ExportLargeFile.pas
@@ -25,6 +25,7 @@ end;
  *
  * @param filename the prefix of the file to write to
  * @param buffer   the line buffer
+ * @param size     the current size of the buffer; updated automatically by this function
  * @param maxSize  the maximum size of a chunk in bytes before the buffer should be flushed
  * @param text     the new line to add
  *)
@@ -45,9 +46,10 @@ end;
  *
  * @param filename the prefix of the file to write to
  * @param buffer   the line buffer
+ * @param size     the current size of the buffer; updated automatically by this function
  * @see appendLargeFile
  *)
-procedure flushLargeFile(filename: String; buffer: TStringList);
+procedure flushLargeFile(filename: String; buffer: TStringList, var size: Integer);
 begin
     if buffer.count = 0 then begin
         exit;
@@ -55,6 +57,7 @@ begin
 
     buffer.saveToFile(_findFreeLargeFile(filename));
     buffer.clear();
+    size := 0;
 end;
 
 (**

--- a/Edit scripts/ExportLargeFile.pas
+++ b/Edit scripts/ExportLargeFile.pas
@@ -19,47 +19,53 @@ begin
 end;
 
 (**
- * Appends [text] to [filename] while using [lines] as a buffer to write in chunks of [maxSize] lines.
+ * Appends [text] to [filename] while using [buffer] to write in chunks of [maxSize] lines.
  *
  * The first chunk is written to `[filename].001`, the second to `[filename].002`, and so on.
  *
  * @param filename the prefix of the file to write to
- * @param lines    the line buffer
- * @param maxSize  the maximum size of a chunk before the buffer should be flushed
+ * @param buffer   the line buffer
+ * @param maxSize  the maximum size of a chunk in bytes before the buffer should be flushed
  * @param text     the new line to add
  *)
-procedure appendLargeFile(filename: String; lines: TStringList; maxSize: Integer; text: String);
+procedure appendLargeFile(filename: String; buffer: TStringList; var size: Integer; maxSize: Integer; text: String);
 begin
-    lines.add(text);
+    buffer.add(text);
+    size := size + length(text) + 1;
 
-    if lines.count >= maxSize then begin
-        lines.saveToFile(_findFreeLargeFile(filename));
-        lines.clear();
+    if size >= maxSize then begin
+        buffer.saveToFile(_findFreeLargeFile(filename));
+        buffer.clear();
+        size := 0;
     end;
 end;
 
 (**
- * Flushes the line buffer [lines] to a [filename] part even if the buffer is not file.
+ * Flushes [buffer] to a [filename] part even if the buffer is not full.
  *
  * @param filename the prefix of the file to write to
- * @param lines    the line buffer
+ * @param buffer   the line buffer
  * @see appendLargeFile
  *)
-procedure flushLargeFile(filename: String; lines: TStringList);
+procedure flushLargeFile(filename: String; buffer: TStringList);
 begin
-    lines.saveToFile(_findFreeLargeFile(filename));
-    lines.clear();
+    if buffer.count = 0 then begin
+        exit;
+    end;
+
+    buffer.saveToFile(_findFreeLargeFile(filename));
+    buffer.clear();
 end;
 
 (**
- * Frees the line buffer [lines] from memory.
+ * Frees the line buffer [buffer] from memory.
  *
- * @param lines the line buffer to free
+ * @param buffer the line buffer to free
  * @see appendLargeFile
  *)
-procedure freeLargeFile(lines: TStringList);
+procedure freeLargeFile(buffer: TStringList);
 begin
-    lines.free();
+    buffer.free();
 end;
 
 (**

--- a/Edit scripts/ExportTabularIDs.pas
+++ b/Edit scripts/ExportTabularIDs.pas
@@ -6,19 +6,21 @@ uses ExportCore,
      ExportLargeFile;
 
 
-var ExportTabularIDs_outputLines: TStringList;
-var ExportTabularIDs_filePartSize: Integer;
+var ExportTabularIDs_buffer: TStringList;
+var ExportTabularIDs_size: Integer;
+var ExportTabularIDs_maxSize: Integer;
 
 
 function initialize: Integer;
 begin
-    ExportTabularIDs_outputLines := TStringList.create();
-    ExportTabularIDs_filePartSize := 500000;
+    ExportTabularIDs_buffer := TStringList.create();
+    ExportTabularIDs_size := 0;
+    ExportTabularIDs_maxSize := 10000000;
 
     createDir('dumps/');
     clearLargeFiles('dumps/IDs.csv');
 
-    appendLargeFile('dumps/IDs.csv', ExportTabularIDs_outputLines, ExportTabularIDs_filePartSize,
+    appendLargeFile('dumps/IDs.csv', ExportTabularIDs_buffer, ExportTabularIDs_size, ExportTabularIDs_maxSize,
             '"File"'      // Name of the originating ESM
         + ', "Signature"' // Signature
         + ', "Form ID"'   // Form ID
@@ -35,7 +37,7 @@ end;
 
 function process(e: IInterface): Integer;
 begin
-    appendLargeFile('dumps/IDs.csv', ExportTabularIDs_outputLines, ExportTabularIDs_filePartSize,
+    appendLargeFile('dumps/IDs.csv', ExportTabularIDs_buffer, ExportTabularIDs_size, ExportTabularIDs_maxSize,
           escapeCsvString(getFileName(getFile(e))) + ', '
         + escapeCsvString(signature(e)) + ', '
         + escapeCsvString(stringFormID(e)) + ', '
@@ -47,8 +49,8 @@ end;
 
 function finalize: Integer;
 begin
-    flushLargeFile('dumps/IDs.csv', ExportTabularIDs_outputLines);
-    freeLargeFile(ExportTabularIDs_outputLines);
+    flushLargeFile('dumps/IDs.csv', ExportTabularIDs_buffer);
+    freeLargeFile(ExportTabularIDs_buffer);
 end;
 
 

--- a/Edit scripts/ExportWikiTERM.pas
+++ b/Edit scripts/ExportWikiTERM.pas
@@ -1,15 +1,21 @@
 unit ExportWikiTERM;
 
 uses ExportCore,
-     ExportWikiCore;
+     ExportWikiCore,
+     ExportLargeFile;
 
 
 var ExportWikiTERM_outputLines: TStringList;
+var ExportWikiTERM_filePartSize: Integer;
 
 
 function initialize: Integer;
 begin
     ExportWikiTERM_outputLines := TStringList.create();
+    ExportWikiTERM_filePartSize := 500000;
+
+    createDir('dumps/');
+    clearLargeFiles('dumps/TERM.wiki');
 end;
 
 function canProcess(e: IInterface): Boolean;
@@ -36,7 +42,7 @@ begin
         contents := '' + #10 + contents + #10 + #10;
     end;
 
-    ExportWikiTERM_outputLines.add(
+    appendLargeFile('dumps/TERM.wiki', ExportWikiTERM_outputLines, ExportWikiTERM_filePartSize,
           '==[' + getFileName(getFile(term)) + '] ' + evBySign(term, 'FULL') + ' (' + stringFormID(term) + ')==' + #10
         + '{{Transcript|text=' + #10
         + 'Welcome to ROBCO Industries (TM) Termlink' + #10
@@ -48,9 +54,8 @@ end;
 
 function finalize: Integer;
 begin
-    createDir('dumps/');
-    ExportWikiTERM_outputLines.saveToFile('dumps/TERM.wiki');
-    ExportWikiTERM_outputLines.free();
+    flushLargeFile('dumps/TERM.wiki', ExportWikiTERM_outputLines);
+    freeLargeFile(ExportWikiTERM_outputLines);
 end;
 
 

--- a/Edit scripts/ExportWikiTERM.pas
+++ b/Edit scripts/ExportWikiTERM.pas
@@ -5,14 +5,16 @@ uses ExportCore,
      ExportLargeFile;
 
 
-var ExportWikiTERM_outputLines: TStringList;
-var ExportWikiTERM_filePartSize: Integer;
+var ExportWikiTERM_buffer: TStringList;
+var ExportWikiTERM_size: Integer;
+var ExportWikiTERM_maxSize: Integer;
 
 
 function initialize: Integer;
 begin
-    ExportWikiTERM_outputLines := TStringList.create();
-    ExportWikiTERM_filePartSize := 500000;
+    ExportWikiTERM_buffer := TStringList.create();
+    ExportWikiTERM_size := 0;
+    ExportWikiTERM_maxSize := 10000000;
 
     createDir('dumps/');
     clearLargeFiles('dumps/TERM.wiki');
@@ -42,7 +44,7 @@ begin
         contents := '' + #10 + contents + #10 + #10;
     end;
 
-    appendLargeFile('dumps/TERM.wiki', ExportWikiTERM_outputLines, ExportWikiTERM_filePartSize,
+    appendLargeFile('dumps/TERM.wiki', ExportWikiTERM_buffer, ExportWikiTERM_size, ExportWikiTERM_maxSize,
           '==[' + getFileName(getFile(term)) + '] ' + evBySign(term, 'FULL') + ' (' + stringFormID(term) + ')==' + #10
         + '{{Transcript|text=' + #10
         + 'Welcome to ROBCO Industries (TM) Termlink' + #10
@@ -54,8 +56,8 @@ end;
 
 function finalize: Integer;
 begin
-    flushLargeFile('dumps/TERM.wiki', ExportWikiTERM_outputLines);
-    freeLargeFile(ExportWikiTERM_outputLines);
+    flushLargeFile('dumps/TERM.wiki', ExportWikiTERM_buffer);
+    freeLargeFile(ExportWikiTERM_buffer);
 end;
 
 


### PR DESCRIPTION
Split the terminal dumps into chunks, just like the IDs, because as of a few versions ago the terminal entries have become too large to fit in 32-bit memory. To achieve this, large files are now chunkified based on their total byte size rather than by line count, which makes much more sense actually.